### PR TITLE
Add optional `program_name` identifier

### DIFF
--- a/rubylogger.json
+++ b/rubylogger.json
@@ -5,7 +5,7 @@
 		"url"			: "",
 		"regex" : {
 			"rubylogger" : {
-				"pattern" : "^[D,I,N,W,E,F,U], \\[(?<timestamp>\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{6}) #(?<pid>\\d+)\\]\\s+(?<alert_level>\\w+)\\s+--\\s+:\\s+(?<body>\\S.*)$"
+				"pattern" : "^[D,I,N,W,E,F,U], \\[(?<timestamp>\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{6}) #(?<pid>\\d+)\\]\\s+(?<alert_level>\\w+)\\s+--\\s+(?<program_name>[^:]*):\\s+(?<body>\\S.*)$"
 			}
 		},
 		"level-field" : "alert_level",
@@ -22,7 +22,8 @@
 			"source"		: { "kind" : "string", "identifier" : true },
 			"debug_level"	: { "kind" : "string", "identifier" : true },
 			"body"			: { "kind" : "string" },
-                        "pid"           : { "kind" : "integer", "identifier" : true }
+                        "pid"           : { "kind" : "integer", "identifier" : true },
+                        "program_name"  : { "kind" : "string", "identifier" : true }
 		},
 		"sample" : [
 			{


### PR DESCRIPTION
Hi,

ruby logger format also has an optional `ProgName` identifier as can be [seen here](https://ruby-doc.org/stdlib-2.3.1/libdoc/logger/rdoc/Logger.html#class-Logger-label-Format):

> SeverityID, [DateTime #pid] SeverityLabel -- ProgName: message

This PR adds that optional identifier. I have log lines both with and without that identifier, have tested it and everything works smoothly.